### PR TITLE
docs: add Beluga Project to visualisation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -154,6 +154,7 @@ A curated list of awesome [ASD-B](https://en.wikipedia.org/wiki/Automatic_Depend
 ### Visualisation
 
 - [wiedehopf/tar1090](https://github.com/wiedehopf/tar1090) - A great way to view your ADS-B data.
+- [amnesica/BelugaProject](https://github.com/amnesica/BelugaProject) - A web application that displays data of one or multiple, local ADS-B feeders and AIS-data along with additional information on a map interface in the browser.
 - [Grafana](https://grafana.com/) - Open source analytics and monitoring solution for every database.
 
 ### Apps


### PR DESCRIPTION
## Summary
- Adds [BelugaProject](https://github.com/amnesica/BelugaProject) to the Software > Visualisation section

Closes #23

## Test plan
- [ ] Verify the link resolves correctly
- [ ] Verify awesome-lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)