### PR TITLE
Add FlightFinder to ADS-B Derived Data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -169,6 +169,7 @@ A curated list of awesome [ASD-B](https://en.wikipedia.org/wiki/Automatic_Depend
 
 ## ADS-B Derived Data
 - [aircraft-flight-schedules](https://github.com/MrAirspace/aircraft-flight-schedules) - Open-source datasets featuring global, high-level flight schedules extracted from worldwide aircraft ADS-B position transmissions (2024+ onwards). Covers all flights globally as long as within coverage of the [ADSBlol](https://adsb.lol/) initiative.
+- [FlightFinder](https://himaxym.com) - Aviation-safety database with tail-number dossiers, live aircraft positions, sighting history and observed-route statistics derived from community ADS-B data provided by the [ADSBlol](https://adsb.lol/) initiative.
 
 ## Hardware
 


### PR DESCRIPTION
Adds [FlightFinder](https://himaxym.com) to the **ADS-B Derived Data** section.

FlightFinder is an aviation-safety database whose live-tracking features are built on community ADS-B data from the [ADSBlol](https://adsb.lol/) initiative: tail-number dossiers with live positions, per-aircraft sighting history, and observed-route statistics aggregated from ADS-B sightings. The underlying scraper tooling is open source (Apache-2.0): https://github.com/disclaimer8/aviation-safety-scrapers

Follows the item format (added to the bottom of the section, description starts with a capital and ends with a period).

🤖 Generated with [Claude Code](https://claude.com/claude-code)