### PR TITLE
docs: add GLASSDECK to visualisation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -156,6 +156,7 @@ A curated list of awesome [ASD-B](https://en.wikipedia.org/wiki/Automatic_Depend
 - [wiedehopf/tar1090](https://github.com/wiedehopf/tar1090) - A great way to view your ADS-B data.
 - [amnesica/BelugaProject](https://github.com/amnesica/BelugaProject) - A web application that displays data of one or multiple, local ADS-B feeders and AIS-data along with additional information on a map interface in the browser.
 - [Grafana](https://grafana.com/) - Open source analytics and monitoring solution for every database.
+- [GLASSDECK](https://github.com/debeers-labs/glassdeck) - A self-contained 3D dashboard for adsb.im feeders, showing your own traffic over your antenna's real measured range, read-only against tar1090 and graphs1090's own data.
 
 ### Apps
 


### PR DESCRIPTION
GLASSDECK is a self-contained 3D dashboard for adsb.im feeders — a "holotable" view of your own traffic over your antenna's real measured range, built read-only against tar1090/graphs1090's own data (no container modification, no duplicated settings).

- Repo: https://github.com/debeers-labs/glassdeck
- Live demo / network globe: https://globe.debeers-labs.xyz

Added one entry to the Visualisation section, following the existing format.